### PR TITLE
Closes FLY-360: Handled custom classes with empty lists defined in YAML

### DIFF
--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -37,6 +37,23 @@ public:
 
   virtual ~ZedCamera();
 
+  // Adapted from https://github.com/RobotecAI/ROSCon2023Demo/pull/141/files
+  // to fix the following error: https://github.com/ros2/rclcpp/issues/1955
+  template<typename Container>
+  Container filterDefaultConstructedElements(const Container& container) {
+    Container filteredContainer;
+    using T = typename Container::value_type;
+    std::copy_if(
+      container.begin(),
+      container.end(),
+      std::back_inserter(filteredContainer),
+      [](const T element){
+          return element != T();
+      });
+
+      return filteredContainer;
+  }
+
 protected:
   // ----> Initialization functions
   void initParameters();
@@ -403,7 +420,7 @@ private:
   sl::OBJECT_DETECTION_MODEL mObjDetModel =
     sl::OBJECT_DETECTION_MODEL::MULTI_CLASS_BOX_FAST;
   sl::OBJECT_FILTERING_MODE mObjFilterMode = sl::OBJECT_FILTERING_MODE::NMS3D;
-  std::vector<int64_t> mObjDetCustomClasses;
+  std::vector<int64_t> mObjDetCustomClasses{};
 
   bool mBodyTrkEnabled = false;
   sl::BODY_TRACKING_MODEL mBodyTrkModel =

--- a/zed_wrapper/config/common.yaml
+++ b/zed_wrapper/config/common.yaml
@@ -126,7 +126,7 @@
             od_enabled: true # True to enable Object Detection
             allow_reduced_precision_inference: true # Allow inference to run at a lower precision to improve runtime and memory usage
             model: "CUSTOM_BOX_OBJECTS" # 'MULTI_CLASS_BOX_FAST', 'MULTI_CLASS_BOX_MEDIUM', 'MULTI_CLASS_BOX_ACCURATE', 'PERSON_HEAD_BOX_FAST', 'PERSON_HEAD_BOX_ACCURATE', 'CUSTOM_BOX_OBJECTS'
-            max_range: 5.0 # [m] Defines a upper depth range for detections
+            max_range: 3.0 # [m] Defines a upper depth range for detections
             confidence_threshold: 50.0 # [DYNAMIC] - Minimum value of the detection confidence of an object [0,99]
             prediction_timeout: 0.5 # During this time [sec], the object will have OK state even if it is not detected. Set this parameter to 0 to disable SDK predictions
             filtering_mode: 1 # '0': NONE - '1': NMS3D - '2': NMS3D_PER_CLASS
@@ -137,7 +137,9 @@
             mc_electronics: false # [DYNAMIC] - Enable/disable the detection of electronic devices for 'MULTI_CLASS_X' models
             mc_fruit_vegetable: false # [DYNAMIC] - Enable/disable the detection of fruits and vegetables for 'MULTI_CLASS_X' models
             mc_sport: false # [DYNAMIC] - Enable/disable the detection of sport-related objects for 'MULTI_CLASS_X' models
-            mc_custom_classes: [47] # [DYNAMIC] - Specify list of retrieved classes for 'CUSTOM_BOX_OBJECTS' model. Leave empty to get all classes. For IDs see: https://github.com/ultralytics/yolov5/blob/master/data/coco.yaml
+            # [DYNAMIC] - Specify list of retrieved classes for 'CUSTOM_BOX_OBJECTS' model.
+            # Leave [""] to get all classes. For IDs see: https://github.com/ultralytics/yolov5/blob/master/data/coco.yaml
+            mc_custom_classes: ["47"]
             object_tracking_enabled: true
             custom_trt_engine_folder: "/home/apple/workdir"
 


### PR DESCRIPTION
Poor handling of empty list params in ROS2/YAML resulted in:

1) workaround to handle empty list with string array: [ "" ]

2) implicit initialization of lists with default constructors (e.g., 0 for ints) that require filtering

This PR fixes it.

Helpful links

https://github.com/ros2/rclcpp/issues/1955

https://github.com/RobotecAI/ROSCon2023Demo/pull/141/files 